### PR TITLE
Respect lstmLoadMode when BUILD_STATIC_RTNEURAL is off

### DIFF
--- a/NeuralAudio/NeuralModel.cpp
+++ b/NeuralAudio/NeuralModel.cpp
@@ -227,7 +227,7 @@ namespace NeuralAudio
 				}
 #endif
 
-				if (newModel == nullptr)
+				if (newModel == nullptr && lstmLoadMode == EModelLoadMode::Internal)
 				{
 					if (numLayers == 1)
 					{


### PR DESCRIPTION
As per title, when BUILD_STATIC_RTNEURAL is off (or the supported fixed sizes dont match the loading model) I found that the internal LSTM implementation was being used.
It should check the preferred load mode in this case too.
