### PR TITLE
Don't assume json samplerate value to be float

### DIFF
--- a/NeuralAudio/NeuralModel.cpp
+++ b/NeuralAudio/NeuralModel.cpp
@@ -277,12 +277,12 @@ namespace NeuralAudio
 
 	void NeuralModel::ReadNAMConfig(const nlohmann::json& modelJson)
 	{
-		if (modelJson.contains("samplerate"))
+		if (modelJson.contains("samplerate") && modelJson["samplerate"].is_number_float())
 		{
 			sampleRate = modelJson["samplerate"];
 		}
 
-		if (modelJson.contains("sample_rate"))
+		if (modelJson.contains("sample_rate") && modelJson["sample_rate"].is_number_float())
 		{
 			sampleRate = modelJson["sample_rate"];
 		}
@@ -310,7 +310,7 @@ namespace NeuralAudio
 
 	void NeuralModel::ReadKerasConfig(const nlohmann::json& modelJson)
 	{
-		if (modelJson.contains("samplerate"))
+		if (modelJson.contains("samplerate") && modelJson["samplerate"].is_number_float())
 		{
 			sampleRate = modelJson["samplerate"];
 		}


### PR DESCRIPTION
One of my local files contains the following:

```
    ],
    "samplerate": "48000",
    "author": "Aida DSP",
    "esr": 0.08318173885345459
}
```

Sample rate there is a string, due to how nlohmann::json works trying to read that value as float/number throws an exception, and then this model file fails to load.

There are already a few checks around this code for ensuring float number, so in this PR I added them for the sample rate too.