### PR TITLE
Use std::runtime_error instead of assert to signal wrong number of weights

### DIFF
--- a/NeuralAudio/WaveNet.h
+++ b/NeuralAudio/WaveNet.h
@@ -371,7 +371,12 @@ namespace NeuralAudio
 
 			headScale = *(it++);
 
-			assert(std::distance(weights.begin(), it) == (long)weights.size());
+      if (std::distance(weights.begin(), it) != (long)weights.size())
+      {
+        std::stringstream str;
+        str << "Wrong number of weights. Remaining: " << std::distance(weights.begin(), it);
+        throw std::runtime_error(str.str());
+      }
 		}
 
 		size_t GetMaxFrames()


### PR DESCRIPTION
When passing a .nam file with the wrong number of weights using assert crashes the process. Using a std::runtime_error allows the caller to catch the error and handle it appropriately.