### PR TITLE
use leftCols(numFrames) of head instead of the whole matrix

### DIFF
--- a/NeuralAudio/WaveNet.h
+++ b/NeuralAudio/WaveNet.h
@@ -223,9 +223,9 @@ namespace NeuralAudio
 			//	data[pos] = WAVENET_MATH::Tanh(data[pos]);
 			//}
 
-			const_cast<Eigen::MatrixBase<Derived2>&>(headInput).noalias() += block.topRows(Channels);
+			const_cast<Eigen::MatrixBase<Derived2>&>(headInput).leftCols(numFrames).noalias() += block;
 
-			oneByOne.Process(block.topRows(Channels), const_cast<Eigen::MatrixBase<Derived3>&>(output).middleCols(outputStart, numFrames));
+			oneByOne.Process(block, const_cast<Eigen::MatrixBase<Derived3>&>(output).middleCols(outputStart, numFrames));
 
 			const_cast<Eigen::MatrixBase<Derived3>&>(output).middleCols(outputStart, numFrames).noalias() += layerBuffer.middleCols(bufferStart, numFrames);
 		}


### PR DESCRIPTION
Use `leftCols(numFrames)` instead. This should only make a difference if `numFrames` is smaller than the maximum number of frames.

Also remove the `topRows(Channels)` - isn't it a no-op since the block hast `Channels` rows anyways.

Maybe I misunderstood the code though ;)