### PR TITLE
Add NeuralModelLoader class

### DIFF
--- a/NeuralAudio/InternalModel.h
+++ b/NeuralAudio/InternalModel.h
@@ -92,7 +92,7 @@ namespace NeuralAudio
 
 			model->SetWeights(modelJson.at("weights"));
 
-			SetMaxAudioBufferSize(defaultMaxAudioBufferSize);
+			SetMaxAudioBufferSize(loader->GetDefaultMaxAudioBufferSize());
 
 			return true;
 		}
@@ -210,7 +210,7 @@ namespace NeuralAudio
 
 			model->SetWeights(modelJson.at("weights"));
 
-			SetMaxAudioBufferSize(defaultMaxAudioBufferSize);
+			SetMaxAudioBufferSize(loader->GetDefaultMaxAudioBufferSize());
 
 			return true;
 		}
@@ -282,7 +282,7 @@ namespace NeuralAudio
 
 			model->SetNAMWeights(modelJson.at("weights"));
 
-			SetMaxAudioBufferSize(defaultMaxAudioBufferSize);
+			SetMaxAudioBufferSize(loader->GetDefaultMaxAudioBufferSize());
 
 			return true;
 		}
@@ -444,7 +444,7 @@ namespace NeuralAudio
 
 			model->SetNAMWeights(modelJson.at("weights"));
 
-			SetMaxAudioBufferSize(defaultMaxAudioBufferSize);
+			SetMaxAudioBufferSize(loader->GetDefaultMaxAudioBufferSize());
 
 			return true;
 		}

--- a/NeuralAudio/NAMModel.h
+++ b/NeuralAudio/NAMModel.h
@@ -16,8 +16,6 @@ namespace NeuralAudio
 		NAMModel()
 		{
 			nam::activations::Activation::enable_fast_tanh();
-
-			slimmableSize = defaultQualityScaleFactor;
 		}
 
 		~NAMModel()
@@ -36,6 +34,8 @@ namespace NeuralAudio
 			if (namModel)
 				namModel.reset();
 
+			slimmableSize = loader->GetDefaultQualityScaleFactor();
+
 			ReadNAMConfig(modelJson);
 
 			namModel = nam::get_dsp(modelJson);
@@ -51,7 +51,7 @@ namespace NeuralAudio
 				slim->SetSlimmableSize(slimmableSize);
 			}
 
-			SetMaxAudioBufferSize(defaultMaxAudioBufferSize);
+			SetMaxAudioBufferSize(loader->GetDefaultMaxAudioBufferSize());
 
 			return true;
 		}

--- a/NeuralAudio/NeuralModel.cpp
+++ b/NeuralAudio/NeuralModel.cpp
@@ -282,7 +282,7 @@ namespace NeuralAudio
 #ifdef BUILD_STATIC_RTNEURAL
 				if (lstmLoadMode == EModelLoadMode::RTNeural)
 				{
-					newModel = RTNeuralLoadKeras(modelJson);
+					newModel = RTNeuralLoadKeras(modelJson, this);
 				}
 #endif
 

--- a/NeuralAudio/NeuralModel.cpp
+++ b/NeuralAudio/NeuralModel.cpp
@@ -85,7 +85,7 @@ namespace NeuralAudio
 		return true;
 	}
 
-	bool NeuralModel::SupportsWaveNetLoadMode(EModelLoadMode mode)
+	bool NeuralModelLoader::SupportsWaveNetLoadMode(EModelLoadMode mode)
 	{
 		if (mode == EModelLoadMode::NAMCore)
 #ifdef BUILD_NAMCORE
@@ -104,7 +104,7 @@ namespace NeuralAudio
 		return true;
 	}
 
-	bool NeuralModel::SupportsLSTMLoadMode(EModelLoadMode mode)
+	bool NeuralModelLoader::SupportsLSTMLoadMode(EModelLoadMode mode)
 	{
 		if (mode == EModelLoadMode::NAMCore)
 #ifdef BUILD_NAMCORE
@@ -116,7 +116,7 @@ namespace NeuralAudio
 		return true;
 	}
 
-	NeuralModel* NeuralModel::CreateFromFile(std::filesystem::path modelPath)
+	NeuralModel* NeuralModelLoader::CreateFromFile(std::filesystem::path modelPath)
 	{
 		if (!std::filesystem::exists(modelPath))
 			return nullptr;
@@ -137,7 +137,7 @@ namespace NeuralAudio
 		return (major > 0) || (minor > 5) || ((minor == 5) && (patch > 4));
 	}
 
-	NeuralModel* NeuralModel::CreateFromStream(std::basic_istream<char>& jsonStream, std::filesystem::path extension)
+	NeuralModel* NeuralModelLoader::CreateFromStream(std::basic_istream<char>& jsonStream, std::filesystem::path extension)
 	{
 		EnsureModelDefsAreLoaded();
 
@@ -155,6 +155,7 @@ namespace NeuralAudio
 			{
 				NAMModel* model = new NAMModel;
 
+				model->SetModelLoader(this);
 				model->LoadFromJson(modelJson);
 
 				newModel = model;
@@ -197,7 +198,7 @@ namespace NeuralAudio
 								if (wavenetLoadMode == EModelLoadMode::RTNeural)
 								{
 #ifdef BUILD_STATIC_RTNEURAL
-									newModel = RTNeuralLoadNAMWaveNet(modelJson);
+									newModel = RTNeuralLoadNAMWaveNet(modelJson, this);
 #endif
 								}
 
@@ -209,6 +210,7 @@ namespace NeuralAudio
 									{
 										auto model = modelDef->CreateModel();
 
+										model->SetModelLoader(this);
 										model->LoadFromNAMJson(modelJson);
 
 										newModel = model;
@@ -223,6 +225,8 @@ namespace NeuralAudio
 						// Use a dynamic model if we had no static definition
 						InternalWaveNetModelDyn* model = new InternalWaveNetModelDyn;
 
+						model->SetModelLoader(this);
+
 						if (model->LoadFromNAMJson(modelJson))
 						{
 							newModel = model;
@@ -234,7 +238,7 @@ namespace NeuralAudio
 #ifdef BUILD_STATIC_RTNEURAL
 					if (lstmLoadMode == EModelLoadMode::RTNeural)
 					{
-						newModel = RTNeuralLoadNAMLSTM(modelJson);
+						newModel = RTNeuralLoadNAMLSTM(modelJson, this);
 					}
 #endif
 
@@ -254,6 +258,8 @@ namespace NeuralAudio
 						if (newModel == nullptr)
 						{
 							InternalLSTMModelDyn* model = new InternalLSTMModelDyn;
+
+							model->SetModelLoader(this);
 
 							if (model->LoadFromNAMJson(modelJson))
 							{

--- a/NeuralAudio/NeuralModel.h
+++ b/NeuralAudio/NeuralModel.h
@@ -22,49 +22,8 @@ namespace NeuralAudio
 	class NeuralModel
 	{
 	public:
-		static NeuralModel* CreateFromFile(std::filesystem::path modelPath);
-		static NeuralModel* CreateFromStream(std::basic_istream<char>& stream, std::filesystem::path extension);
-
 		virtual ~NeuralModel()
 		{
-		}
-
-		static bool SetLSTMLoadMode(EModelLoadMode val)
-		{
-			if (!SupportsLSTMLoadMode(val))
-				return false;
-
-			lstmLoadMode = val;
-
-			return true;
-		}
-
-		static bool SetWaveNetLoadMode(EModelLoadMode val)
-		{
-			if (!SupportsWaveNetLoadMode(val))
-				return false;
-
-			wavenetLoadMode = val;
-
-			return true;
-		}
-
-		static bool SupportsWaveNetLoadMode(EModelLoadMode mode);
-		static bool SupportsLSTMLoadMode(EModelLoadMode mode);
-
-		static void SetAudioInputLevelDBu(float audioDBu)
-		{
-			audioInputLevelDBu = audioDBu;
-		}
-
-		static void SetDefaultMaxAudioBufferSize(int maxSize)
-		{
-			defaultMaxAudioBufferSize = maxSize;
-		}
-
-		static void SetDefaultQualityScaleFactor(float scaleFactor)
-		{
-			defaultQualityScaleFactor = scaleFactor;
 		}
 
 		virtual EModelLoadMode GetLoadMode()
@@ -149,17 +108,80 @@ namespace NeuralAudio
 		}
 
 	protected:
+		float audioInputLevelDBu = 12;
 		float modelInputLevelDBu = 12;
 		float modelOutputLevelDBu = 12;
 		float modelLoudnessDB = -18;
 		float sampleRate = 48000;
 		std::string modelVersion = "";
 		std::vector<std::pair<std::string, std::string>> metadata;
-
-		inline static float audioInputLevelDBu = 12;
-		inline static EModelLoadMode lstmLoadMode = EModelLoadMode::Internal;
-		inline static EModelLoadMode wavenetLoadMode = EModelLoadMode::Internal;
-		inline static int defaultMaxAudioBufferSize = 128;
-		inline static float defaultQualityScaleFactor = DEFAULT_QUALITY_SCALE;
 	};
+
+	class NeuralModelLoader
+	{
+		public:
+			NeuralModel* CreateFromFile(std::filesystem::path modelPath);
+			NeuralModel* CreateFromStream(std::basic_istream<char>& stream, std::filesystem::path extension);
+
+			bool SetLSTMLoadMode(EModelLoadMode val)
+			{
+				if (!SupportsLSTMLoadMode(val))
+					return false;
+
+				lstmLoadMode = val;
+
+				return true;
+			}
+
+			bool SetWaveNetLoadMode(EModelLoadMode val)
+			{
+				if (!SupportsWaveNetLoadMode(val))
+					return false;
+
+				wavenetLoadMode = val;
+
+				return true;
+			}
+
+			bool SupportsWaveNetLoadMode(EModelLoadMode mode);
+			bool SupportsLSTMLoadMode(EModelLoadMode mode);
+
+			void SetAudioInputLevelDBu(float audioDBu)
+			{
+				audioInputLevelDBu = audioDBu;
+			}
+
+			float GetAudioInputLevelDBu()
+			{
+				return audioInputLevelDBu;
+			}
+
+			void SetDefaultMaxAudioBufferSize(int maxSize)
+			{
+				defaultMaxAudioBufferSize = maxSize;
+			}
+
+			int GetDefaultMaxAudioBufferSize()
+			{
+				return defaultMaxAudioBufferSize;
+			}
+
+			void SetDefaultQualityScaleFactor(float scaleFactor)
+			{
+				defaultQualityScaleFactor = scaleFactor;
+			}
+
+			float GetDefaultQualityScaleFactor()
+			{
+				return defaultQualityScaleFactor;
+			}
+
+		protected:
+			EModelLoadMode lstmLoadMode = EModelLoadMode::Internal;
+			EModelLoadMode wavenetLoadMode = EModelLoadMode::Internal;
+			float audioInputLevelDBu = 12;
+			int defaultMaxAudioBufferSize = 128;
+			float defaultQualityScaleFactor = DEFAULT_QUALITY_SCALE;
+	};
+
 }

--- a/NeuralAudio/NeuralModelImpl.h
+++ b/NeuralAudio/NeuralModelImpl.h
@@ -10,6 +10,11 @@ namespace NeuralAudio
 		public:
 			using NeuralModel::Prewarm;
 
+			void SetModelLoader(NeuralModelLoader* loader)
+			{
+				this->loader = loader;
+			}
+
 		protected:
 			void ReadNAMConfig(const nlohmann::json& modelJson)
 			{
@@ -96,5 +101,7 @@ namespace NeuralAudio
 					Process(input.data(), output.data(), blockSize);
 				}
 			}
+
+			NeuralModelLoader *loader;
 	};
 }

--- a/NeuralAudio/RTNeuralLoader.cpp
+++ b/NeuralAudio/RTNeuralLoader.cpp
@@ -86,7 +86,7 @@ namespace NeuralAudio
 			// If we didn't have a static model that matched, use RTNeural's dynamic model
 			RTNeuralModelDyn* dynModel = new RTNeuralModelDyn;
 
-			dynmodel->SetModelLoader(loader);
+			dynModel->SetModelLoader(loader);
 			dynModel->LoadFromNAMJson(modelJson);
 
 			return dynModel;
@@ -94,7 +94,7 @@ namespace NeuralAudio
 			return nullptr;
 		}
 
-		NeuralModel* RTNeuralLoadKeras(const nlohmann::json& modelJson)
+		NeuralModel* RTNeuralLoadKeras(const nlohmann::json& modelJson, NeuralModelLoader* loader)
 		{
 			const auto layers = modelJson.at("layers");
 			const size_t numLayers = layers.size() - 1;
@@ -107,6 +107,7 @@ namespace NeuralAudio
 			{
 				RTNeuralModel* model = modelDef->CreateModel();
 
+				model->SetModelLoader(loader);
 				model->LoadFromKerasJson(modelJson);
 
 				return model;

--- a/NeuralAudio/RTNeuralLoader.cpp
+++ b/NeuralAudio/RTNeuralLoader.cpp
@@ -45,7 +45,7 @@ namespace NeuralAudio
 			return nullptr;
 		}
 
-		NeuralModel* RTNeuralLoadNAMWaveNet(const nlohmann::json& modelJson)
+		NeuralModel* RTNeuralLoadNAMWaveNet(const nlohmann::json& modelJson, NeuralModelLoader *loader)
 		{
 			nlohmann::json config = modelJson.at("config");
 
@@ -58,6 +58,7 @@ namespace NeuralAudio
 			{
 				auto model = modelDef->CreateModel();
 
+				model->SetModelLoader(loader);
 				model->LoadFromNAMJson(modelJson);
 
 				return model;
@@ -66,7 +67,7 @@ namespace NeuralAudio
 			return nullptr;
 		}
 
-		NeuralModel* RTNeuralLoadNAMLSTM(const nlohmann::json& modelJson)
+		NeuralModel* RTNeuralLoadNAMLSTM(const nlohmann::json& modelJson, NeuralModelLoader *loader)
 		{
 			nlohmann::json config = modelJson.at("config");
 
@@ -75,17 +76,20 @@ namespace NeuralAudio
 			if (modelDef != nullptr)
 			{
 				RTNeuralModel* model = modelDef->CreateModel();
+
+				model->SetModelLoader(loader);
 				model->LoadFromNAMJson(modelJson);
 
-				if (model != nullptr)
-					return model;
-
-				// If we didn't have a static model that matched, use RTNeural's dynamic model
-				RTNeuralModelDyn* dynModel = new RTNeuralModelDyn;
-				dynModel->LoadFromNAMJson(modelJson);
-
-				return dynModel;
+				return model;
 			}
+
+			// If we didn't have a static model that matched, use RTNeural's dynamic model
+			RTNeuralModelDyn* dynModel = new RTNeuralModelDyn;
+
+			dynmodel->SetModelLoader(loader);
+			dynModel->LoadFromNAMJson(modelJson);
+
+			return dynModel;
 
 			return nullptr;
 		}

--- a/NeuralAudio/RTNeuralLoader.h
+++ b/NeuralAudio/RTNeuralLoader.h
@@ -6,7 +6,7 @@
 namespace NeuralAudio
 {
 	extern void EnsureRTNeuralModelDefsAreLoaded();
-	extern NeuralModel* RTNeuralLoadNAMWaveNet(const nlohmann::json& modelJson);
-	extern NeuralModel* RTNeuralLoadNAMLSTM(const nlohmann::json& modelJson);
-	extern NeuralModel* RTNeuralLoadKeras(const nlohmann::json& modelJson);
+	extern NeuralModel* RTNeuralLoadNAMWaveNet(const nlohmann::json& modelJson, NeuralModelLoader* loader);
+	extern NeuralModel* RTNeuralLoadNAMLSTM(const nlohmann::json& modelJson, NeuralModelLoader* loader);
+	extern NeuralModel* RTNeuralLoadKeras(const nlohmann::json& modelJson, NeuralModelLoader* loader);
 }

--- a/NeuralAudio/RTNeuralModel.h
+++ b/NeuralAudio/RTNeuralModel.h
@@ -282,7 +282,7 @@ namespace NeuralAudio
 
 			model->load_weights(modelJson);
 
-			SetMaxAudioBufferSize(defaultMaxAudioBufferSize);
+			SetMaxAudioBufferSize(loader->GetDefaultMaxAudioBufferSize());
 
 			return true;
 		}

--- a/NeuralAudioCAPI/NeuralAudioCApi.cpp
+++ b/NeuralAudioCAPI/NeuralAudioCApi.cpp
@@ -6,11 +6,31 @@ struct NeuralModel
     NeuralAudio::NeuralModel* model;
 };
 
-NeuralModel* CreateModelFromFile(const wchar_t* modelPath)
+struct NeuralModelLoader
+{
+	NeuralAudio::NeuralModelLoader* loader;
+};
+
+NeuralModelLoader* CreateLoader()
+{
+	NeuralModelLoader* loader = new NeuralModelLoader();
+
+	loader->loader = new NeuralAudio::NeuralModelLoader();
+
+	return loader;
+}
+
+void DeleteLoader(NeuralModelLoader* loader)
+{
+	delete loader->loader;
+	delete loader;
+}
+
+NeuralModel* CreateModelFromFile(NeuralModelLoader* loader, const wchar_t* modelPath)
 {
     NeuralModel* model = new NeuralModel();
 
-    model->model = NeuralAudio::NeuralModel::CreateFromFile(modelPath);
+    model->model = loader->loader->CreateFromFile(modelPath);
 
     return model;
 }
@@ -21,24 +41,24 @@ void DeleteModel(NeuralModel* model)
     delete model;
 }
 
-void SetLSTMLoadMode(int loadMode)
+void SetLSTMLoadMode(NeuralModelLoader* loader, int loadMode)
 {
-	NeuralAudio::NeuralModel::SetLSTMLoadMode((NeuralAudio::EModelLoadMode)loadMode);
+	loader->loader->SetLSTMLoadMode((NeuralAudio::EModelLoadMode)loadMode);
 }
 
-void SetWaveNetLoadMode(int loadMode)
+void SetWaveNetLoadMode(NeuralModelLoader* loader, int loadMode)
 {
-	NeuralAudio::NeuralModel::SetWaveNetLoadMode((NeuralAudio::EModelLoadMode)loadMode);
+	loader->loader->SetWaveNetLoadMode((NeuralAudio::EModelLoadMode)loadMode);
 }
 
-void SetAudioInputLevelDBu(float audioDBu)
+void SetAudioInputLevelDBu(NeuralModelLoader* loader, float audioDBu)
 {
-	NeuralAudio::NeuralModel::SetAudioInputLevelDBu(audioDBu);
+	loader->loader->SetAudioInputLevelDBu(audioDBu);
 }
 
-void SetDefaultMaxAudioBufferSize(int maxSize)
+void SetDefaultMaxAudioBufferSize(NeuralModelLoader* loader, int maxSize)
 {
-	NeuralAudio::NeuralModel::SetDefaultMaxAudioBufferSize(maxSize);
+	loader->loader->SetDefaultMaxAudioBufferSize(maxSize);
 }
 
 int GetLoadMode(NeuralModel* model)

--- a/NeuralAudioCAPI/NeuralAudioCApi.h
+++ b/NeuralAudioCAPI/NeuralAudioCApi.h
@@ -13,19 +13,23 @@ extern "C" {
 #endif
 
 struct NeuralModel;
+struct NeuralModelLoader;
 
+NA_EXTERN NeuralModelLoader* CreateLoader();
 
-NA_EXTERN NeuralModel* CreateModelFromFile(const wchar_t* modelPath);
+NA_EXTERN void DeleteLoader(NeuralModelLoader* loader);
+
+NA_EXTERN NeuralModel* CreateModelFromFile(NeuralModelLoader *loader, const wchar_t* modelPath);
 
 NA_EXTERN void DeleteModel(NeuralModel* model);
 
-NA_EXTERN void SetLSTMLoadMode(int loadMode);
+NA_EXTERN void SetLSTMLoadMode(NeuralModelLoader* loader, int loadMode);
 
-NA_EXTERN void SetWaveNetLoadMode(int loadMode);
+NA_EXTERN void SetWaveNetLoadMode(NeuralModelLoader* loader, int loadMode);
 
-NA_EXTERN void SetAudioInputLevelDBu(float audioDBu);
+NA_EXTERN void SetAudioInputLevelDBu(NeuralModelLoader* loader, float audioDBu);
 
-NA_EXTERN void SetDefaultMaxAudioBufferSize(int maxSize);
+NA_EXTERN void SetDefaultMaxAudioBufferSize(NeuralModelLoader* loader, int maxSize);
 
 NA_EXTERN int GetLoadMode(NeuralModel* model);
 

--- a/NeuralAudioCSharp/NeuralAudio/NativeApi.cs
+++ b/NeuralAudioCSharp/NeuralAudio/NativeApi.cs
@@ -9,22 +9,28 @@ namespace NeuralAudio
         public const string NEURAL_AUDIO_LIB_NAME = "NeuralAudioCAPI";
 
         [DllImport(NEURAL_AUDIO_LIB_NAME)]
-        public static extern IntPtr CreateModelFromFile([MarshalAs(UnmanagedType.LPWStr)]string modelPath);
+        public static extern IntPtr CreateLoader();
+
+        [DllImport(NEURAL_AUDIO_LIB_NAME)]
+        public static extern void DeleteLoader(IntPtr loader);
+
+        [DllImport(NEURAL_AUDIO_LIB_NAME)]
+        public static extern IntPtr CreateModelFromFile(IntPtr loader, [MarshalAs(UnmanagedType.LPWStr)]string modelPath);
 
         [DllImport(NEURAL_AUDIO_LIB_NAME)]
         public static extern void DeleteModel(IntPtr model);
 
         [DllImport(NEURAL_AUDIO_LIB_NAME)]
-        public static extern void SetLSTMLoadMode(int loadMode);
+        public static extern void SetLSTMLoadMode(IntPtr loader, int loadMode);
 
         [DllImport(NEURAL_AUDIO_LIB_NAME)]
-        public static extern void SetWaveNetLoadMode(int loadMode);
+        public static extern void SetWaveNetLoadMode(IntPtr loader, int loadMode);
 
         [DllImport(NEURAL_AUDIO_LIB_NAME)]
-        public static extern void SetAudioInputLevelDBu(float audioDBu);
+        public static extern void SetAudioInputLevelDBu(IntPtr loader, float audioDBu);
 
         [DllImport(NEURAL_AUDIO_LIB_NAME)]
-        public static extern void SetDefaultMaxAudioBufferSize(int maxSize);
+        public static extern void SetDefaultMaxAudioBufferSize(IntPtr loader, int maxSize);
 
         [DllImport(NEURAL_AUDIO_LIB_NAME)]
         public static extern int GetLoadMode(IntPtr model);

--- a/NeuralAudioCSharp/NeuralAudio/NeuralModel.cs
+++ b/NeuralAudioCSharp/NeuralAudio/NeuralModel.cs
@@ -3,31 +3,58 @@ using System.Runtime.CompilerServices;
 
 namespace NeuralAudio
 {
+    public enum EModelLoadMode
+    {
+        Internal,
+        RTNeural,
+        NAMCore
+    };
+
+    public class NeuralModelLoader
+    {
+        IntPtr nativeLoader;
+
+        public NeuralModelLoader()
+        {
+            nativeLoader = NativeApi.CreateLoader();
+        }
+
+        ~NeuralModelLoader()
+        {
+            NativeApi.DeleteLoader(nativeLoader);
+        }
+
+        public void SetLSTMModelLoadMode(EModelLoadMode mode)
+        {
+            NativeApi.SetLSTMLoadMode(nativeLoader, (int)mode);
+        }
+
+        public void SetWaveNetModelLoadMode(EModelLoadMode mode)
+        {
+            NativeApi.SetWaveNetLoadMode(nativeLoader, (int)mode);
+        }
+
+        public void SetDefaultMaxAudioBufferSize(int bufferSize)
+        {
+            NativeApi.SetDefaultMaxAudioBufferSize(nativeLoader, bufferSize);
+        }
+
+        public NeuralModel CreateModelFromFile(string modelPath)
+        {
+            NeuralModel model = new NeuralModel();
+
+            model.nativeModel = NativeApi.CreateModelFromFile(nativeLoader, modelPath);
+
+            if (model.nativeModel == IntPtr.Zero)
+                return null;
+
+            return model;
+        }
+    }
+
     public class NeuralModel
     {
-        public enum EModelLoadMode
-        {
-            Internal,
-            RTNeural,
-            NAMCore
-        };
-
-        IntPtr nativeModel;
-
-        public static void SetLSTMModelLoadMode(EModelLoadMode mode)
-        {
-            NativeApi.SetLSTMLoadMode((int)mode);
-        }
-
-        public static void SetWaveNetModelLoadMode(EModelLoadMode mode)
-        {
-            NativeApi.SetWaveNetLoadMode((int)mode);
-        }
-
-        public static void SetDefaultMaxAudioBufferSize(int bufferSize)
-        {
-            NativeApi.SetDefaultMaxAudioBufferSize(bufferSize);
-        }
+        internal IntPtr nativeModel;
 
         public bool IsStatic { get { return NativeApi.IsStatic(nativeModel);  } }
         public EModelLoadMode LoadMode { get { return (EModelLoadMode)NativeApi.GetLoadMode(nativeModel); } }
@@ -35,15 +62,9 @@ namespace NeuralAudio
         public float RecommendedInputDBAdjustment { get { return NativeApi.GetRecommendedInputDBAdjustment(nativeModel); } }
         public float RecommendedOutputDBAdjustment { get { return NativeApi.GetRecommendedOutputDBAdjustment(nativeModel); } }
 
-        public static NeuralModel FromFile(string modelPath)
+        ~NeuralModel()
         {
-            NeuralModel model = new NeuralModel();
-
-            IntPtr nativeModel = NativeApi.CreateModelFromFile(modelPath);
-
-            model.nativeModel = nativeModel;
-
-            return model;
+            NativeApi.DeleteModel(nativeModel);
         }
 
         public void SetMaxAudioBufferSize(int bufferSize)

--- a/NeuralAudioCSharp/NeuralAudioTest/Program.cs
+++ b/NeuralAudioCSharp/NeuralAudioTest/Program.cs
@@ -6,9 +6,11 @@
     {
         static void Main(string[] args)
         {
-            NeuralModel.SetWaveNetModelLoadMode(NeuralModel.EModelLoadMode.Internal);
+            NeuralModelLoader loader = new();
 
-            NeuralModel model = NeuralModel.FromFile("BossWN-standard.nam");
+            loader.SetWaveNetModelLoadMode(EModelLoadMode.Internal);
+
+            NeuralModel model = loader.CreateModelFromFile("BossWN-standard.nam");
 
             var input = new float[1024];
             var output = new float[1024];

--- a/README.md
+++ b/README.md
@@ -33,9 +33,12 @@ NAM A2 models currently use the NAM Core implementation.
 
 # API overview
 
-To load a model:
+Models are loaded with a model loader:
+
 ```
-NeuralModel* model = NeuralAudio::NeuralModel::CreateFromFile("<path to model file>");
+NeuralModelLoader loader;
+
+NeuralModel* model = loader.CreateFromFile("<path to model file>");
 ```
 
 To process a model:
@@ -48,10 +51,10 @@ model->Process(pointerToFloatInputData, pointerToFloatOutputData, int numSamples
 
 Some models need to allocate memory based on the size of the audio buffers being used. You need to make sure that processing does not exceed the specified maximum buffer size.
 
-The default maximum size is 128 samples. To change it, do:
+The default maximum size is 128 samples. To change it, change the default size on the model loader:
 
 ```
-NeuralAudio::NeuralModel::SetDefaultMaxAudioBufferSize(maxSize);
+loader.SetDefaultMaxAudioBufferSize(maxSize);
 ```
 
 if you want to change the maximum buffer size of an already created model, do:
@@ -66,20 +69,20 @@ model->SetMaxAudioBufferSize(int maxSize);
 
 Use ```model->GetRecommendedInputDBAdjustment()``` and ```model->GetRecommendedOutputDBAdjustment()``` to obtain the ideal input and output volume level adjustments in dB.
 
-To set a known audio input level (ie: from an audio interface), use ```model->SetAudioInputLevelDBu(float audioDBu)```. This is set at 12DBu by default.
+To set a known audio input level (ie: from an audio interface), use ```loader.SetAudioInputLevelDBu(float audioDBu)```. This is set at 12DBu by default.
 
 ## Model load behavior
 
 By default, models are loaded using the internal NeuralAudio implementation. If you would like to force the use of the NAM Core or RTNeural implementations, you can use:
 
 ```
-NeuralAudio::NeuralModel::SetWaveNetLoadMode(loadMode)
+loader.SetWaveNetLoadMode(loadMode)
 ```
 
 and
 
 ```
-NeuralAudio::NeuralModel::SetLSTMLoadMode(loadMode)
+loader.SetLSTMLoadMode(loadMode)
 ```
 
 where "loadMode" is one of:
@@ -100,10 +103,10 @@ Some models (notably, slimmable NAM A2 models) support quality scaling - trading
 
 Quality scaling is a floating point range from 0.0 (highest performance) to 1.0 (highest quality).
 
-To set the default quality scaling factor, do:
+To set the default quality scaling factor, set it on the loader:
 
 ```
-NeuralAudio::NeuralModel::SetDefaultQualityScaleFactor(scaleFactor);
+loader.SetDefaultQualityScaleFactor(scaleFactor);
 ```
 
 To check if a model supports quality scaling, do:
@@ -112,11 +115,13 @@ To check if a model supports quality scaling, do:
 if (model->HasQualityScaling()) ...
 ```
 
-To set the quality scaling factor for a model, do:
+To set the quality scaling factor for a loaded model, do:
 
 ```
 model->SetQualityScaleFactor(scaleFactor);
 ```
+
+***Note: This operation is not real-time safe if the quality scale factor results in a change to the model***
 
 To get the quality scaling factor for a model, do:
 

--- a/Utils/ModelTest/ModelTest.cpp
+++ b/Utils/ModelTest/ModelTest.cpp
@@ -8,10 +8,10 @@ using namespace NeuralAudio;
 
 static std::string LoadModes[] = { "Internal", "RTNeural", "NAMCore" };
 
-NeuralModel* LoadModel(std::filesystem::path modelPath, EModelLoadMode loadMode)
+NeuralModel* LoadModel(std::filesystem::path modelPath, NeuralModelLoader& loader, EModelLoadMode loadMode)
 {
-	NeuralModel::SetWaveNetLoadMode(loadMode);
-	NeuralModel::SetLSTMLoadMode(loadMode);
+	loader.SetWaveNetLoadMode(loadMode);
+	loader.SetLSTMLoadMode(loadMode);
 
 	if (!std::filesystem::exists(modelPath))
 	{
@@ -22,7 +22,7 @@ NeuralModel* LoadModel(std::filesystem::path modelPath, EModelLoadMode loadMode)
 
 	try
 	{
-		auto model = NeuralAudio::NeuralModel::CreateFromFile(modelPath);
+		auto model = loader.CreateFromFile(modelPath);
 
 		if (model == nullptr)
 		{
@@ -127,7 +127,7 @@ static double ComputeError(NeuralModel* model1, NeuralModel* model2, int blockSi
 	return sqrt(totErr / (double)(blockSize * numBlocks));
 }
 
-void RunNAMTests(std::filesystem::path modelPath, int blockSize)
+void RunNAMTests(std::filesystem::path modelPath, NeuralModelLoader& loader, int blockSize)
 {
 	std::cout << "Model: " << modelPath << std::endl;
 	std::cout << std::endl;
@@ -136,11 +136,11 @@ void RunNAMTests(std::filesystem::path modelPath, int blockSize)
 
 	int numBlocks = dataSize / blockSize;
 
-	NeuralModel::SetDefaultMaxAudioBufferSize(blockSize);
+	loader.SetDefaultMaxAudioBufferSize(blockSize);
 
-	NeuralModel* rtNeuralModel = LoadModel(modelPath, EModelLoadMode::RTNeural);
-	NeuralModel* namCoreModel = LoadModel(modelPath, EModelLoadMode::NAMCore);
-	NeuralModel* internalModel = LoadModel(modelPath, EModelLoadMode::Internal);
+	NeuralModel* rtNeuralModel = LoadModel(modelPath, loader, EModelLoadMode::RTNeural);
+	NeuralModel* namCoreModel = LoadModel(modelPath, loader, EModelLoadMode::NAMCore);
+	NeuralModel* internalModel = LoadModel(modelPath, loader, EModelLoadMode::Internal);
 
 	double rms;
 
@@ -199,7 +199,7 @@ void RunNAMTests(std::filesystem::path modelPath, int blockSize)
 	std::cout << std::endl;
 }
 
-void RunKerasTests(std::filesystem::path modelPath, int blockSize)
+void RunKerasTests(std::filesystem::path modelPath, NeuralModelLoader& loader, int blockSize)
 {
 	std::cout << "Model: " << modelPath << std::endl;
 
@@ -207,10 +207,10 @@ void RunKerasTests(std::filesystem::path modelPath, int blockSize)
 
 	int numBlocks = dataSize / blockSize;
 
-	NeuralAudio::NeuralModel::SetDefaultMaxAudioBufferSize(blockSize);
+	loader.SetDefaultMaxAudioBufferSize(blockSize);
 
-	auto internalModel = LoadModel(modelPath, EModelLoadMode::Internal);
-	auto rtNeuralModel = LoadModel(modelPath, EModelLoadMode::RTNeural);
+	auto internalModel = LoadModel(modelPath, loader, EModelLoadMode::Internal);
+	auto rtNeuralModel = LoadModel(modelPath, loader, EModelLoadMode::RTNeural);
 
 	double rms = ComputeError(rtNeuralModel, internalModel, blockSize, numBlocks);
 	std::cout << "Internal vs RTNeural RMS err: " << rms << std::endl;
@@ -226,7 +226,7 @@ void RunKerasTests(std::filesystem::path modelPath, int blockSize)
 	std::cout << std::endl;
 }
 
-int RunDefaultTests(int blockSize)
+int RunDefaultTests(NeuralModelLoader& loader, int blockSize)
 {
 	std::filesystem::path modelPath = std::filesystem::current_path();
 
@@ -253,12 +253,12 @@ int RunDefaultTests(int blockSize)
 	std::cout << "Loading models from: " << modelPath << std::endl << std::endl;
 
 	std::cout << "WaveNet (Standard) Test" << std::endl;
-	RunNAMTests(modelPath / "BossWN-standard.nam", blockSize);
+	RunNAMTests(modelPath / "BossWN-standard.nam", loader, blockSize);
 
 	std::cout << std::endl;
 
 	std::cout << "LSTM (1x16) Test" << std::endl;
-	RunNAMTests(modelPath / "BossLSTM-1x16.nam", blockSize);
+	RunNAMTests(modelPath / "BossLSTM-1x16.nam", loader, blockSize);
 
 	return 0;
 }
@@ -308,7 +308,9 @@ int main(int argc, char* argv[])
 
 	qualityScale = program.get<float>("--quality_scale");
 
-	NeuralModel::SetDefaultQualityScaleFactor(qualityScale);
+	NeuralModelLoader loader;
+
+	loader.SetDefaultQualityScaleFactor(qualityScale);
 
 	std::cout << "Block size: " << blockSize << "  Quality Scale: " << qualityScale << std::endl;
 
@@ -316,16 +318,16 @@ int main(int argc, char* argv[])
 	{
 		if (modelPath.extension() == ".nam")
 		{
-			RunNAMTests(modelPath, blockSize);
+			RunNAMTests(modelPath, loader, blockSize);
 		}
 		else
 		{
-			RunKerasTests(modelPath, blockSize);
+			RunKerasTests(modelPath, loader, blockSize);
 		}
 	}
 	else
 	{
-		if (RunDefaultTests(blockSize) < 0)
+		if (RunDefaultTests(loader, blockSize) < 0)
 			return -1;
 	}
 


### PR DESCRIPTION
This adds a NeuralModelLoader class to replace the previous static methods for creating models and managing default behavior. Moving away from static variables prevents any possible unwanted interaction between multiple instances of the library running in the same process space (for example, multiple instances of a plugin in a DAW).