### PR TITLE
Expose Has* metadata flags on NeuralModel

### DIFF
--- a/NeuralAudio/NAMModel.h
+++ b/NeuralAudio/NAMModel.h
@@ -57,6 +57,31 @@ namespace NeuralAudio
 
 			namModel->SetPrewarmOnReset(true);
 
+			// Mirror Has* flags from the underlying NAM core DSP, so callers can
+			// distinguish models whose metadata is truly known from those left at
+			// hard-coded defaults. ReadNAMConfig above already sets the flags when
+			// the JSON metadata block carries loudness/input_level_dbu/output_level_dbu;
+			// this covers the case where the values were injected via the NAM core
+			// itself (dsp::SetLoudness/SetInputLevel/SetOutputLevel).
+			if (namModel)
+			{
+				if (namModel->HasLoudness())
+				{
+					hasLoudnessKnown_ = true;
+					modelLoudnessDB = (float)namModel->GetLoudness();
+				}
+				if (namModel->HasInputLevel())
+				{
+					hasInputLevelKnown_ = true;
+					modelInputLevelDBu = (float)namModel->GetInputLevel();
+				}
+				if (namModel->HasOutputLevel())
+				{
+					hasOutputLevelKnown_ = true;
+					modelOutputLevelDBu = (float)namModel->GetOutputLevel();
+				}
+			}
+
 			return true;
 		}
 

--- a/NeuralAudio/NeuralModel.h
+++ b/NeuralAudio/NeuralModel.h
@@ -89,6 +89,36 @@ namespace NeuralAudio
 			return sampleRate;
 		}
 
+		virtual bool HasLoudness() const
+		{
+			return hasLoudnessKnown_;
+		}
+
+		virtual bool HasInputLevel() const
+		{
+			return hasInputLevelKnown_;
+		}
+
+		virtual bool HasOutputLevel() const
+		{
+			return hasOutputLevelKnown_;
+		}
+
+		virtual float GetLoudnessDB() const
+		{
+			return modelLoudnessDB;
+		}
+
+		virtual float GetInputLevelDBu() const
+		{
+			return modelInputLevelDBu;
+		}
+
+		virtual float GetOutputLevelDBu() const
+		{
+			return modelOutputLevelDBu;
+		}
+
 		virtual int GetReceptiveFieldSize()
 		{
 			return -1;	// No fixed receptive field size (ie: for LSTM)
@@ -133,6 +163,9 @@ namespace NeuralAudio
 		float sampleRate = 48000;
 		std::string modelVersion = "";
 		std::vector<std::pair<std::string, std::string>> metadata;
+		bool hasLoudnessKnown_ = false;
+		bool hasInputLevelKnown_ = false;
+		bool hasOutputLevelKnown_ = false;
 	};
 
 	class NeuralModelLoader

--- a/NeuralAudio/NeuralModelImpl.h
+++ b/NeuralAudio/NeuralModelImpl.h
@@ -43,16 +43,19 @@ namespace NeuralAudio
 					if (metadataJson.contains("loudness") && metadataJson.at("loudness").is_number())
 					{
 						modelLoudnessDB = (float)metadataJson.at("loudness");
+						hasLoudnessKnown_ = true;
 					}
 
 					if (metadataJson.contains("input_level_dbu") && metadataJson.at("input_level_dbu").is_number())
 					{
 						modelInputLevelDBu = metadataJson.at("input_level_dbu");
+						hasInputLevelKnown_ = true;
 					}
 
 					if (metadataJson.contains("output_level_dbu") && metadataJson.at("output_level_dbu").is_number())
 					{
 						modelOutputLevelDBu = metadataJson.at("output_level_dbu");
+						hasOutputLevelKnown_ = true;
 					}
 				}
 			}


### PR DESCRIPTION
Add HasLoudness/HasInputLevel/HasOutputLevel so hosts can skip normalization/calibration when a model lacks real metadata (V1 legacy models fabricate loudness from out_gain).